### PR TITLE
Track global application and window state

### DIFF
--- a/src/api/plugin_export.h
+++ b/src/api/plugin_export.h
@@ -17,6 +17,14 @@ static const char *chunkwm_plugin_export_str[] =
     "chunkwm_export_display_moved",
     "chunkwm_export_display_resized",
 
+    "chunkwm_export_window_created",
+    "chunkwm_export_window_destroyed",
+    "chunkwm_export_window_focused",
+    "chunkwm_export_window_moved",
+    "chunkwm_export_window_resized",
+    "chunkwm_export_window_minimized",
+    "chunkwm_export_window_deminimized",
+
     "chunkwm_export_end",
 };
 enum chunkwm_plugin_export
@@ -34,6 +42,14 @@ enum chunkwm_plugin_export
     chunkwm_export_display_removed,
     chunkwm_export_display_moved,
     chunkwm_export_display_resized,
+
+    chunkwm_export_window_created,
+    chunkwm_export_window_destroyed,
+    chunkwm_export_window_focused,
+    chunkwm_export_window_moved,
+    chunkwm_export_window_resized,
+    chunkwm_export_window_minimized,
+    chunkwm_export_window_deminimized,
 
     chunkwm_export_end,
 };

--- a/src/common/accessibility/application.cpp
+++ b/src/common/accessibility/application.cpp
@@ -158,7 +158,6 @@ std::vector<macos_application *> AXLibRunningProcesses(uint32_t ProcessFlags)
     return Applications;
 }
 
-
 /* NOTE(koekeishiya): Wrap the frontmost application inside a macos_application struct.
  * The caller is responsible for calling 'AXLibDestroyApplication()'. */
 macos_application *AXLibConstructFocusedApplication()

--- a/src/common/accessibility/element.cpp
+++ b/src/common/accessibility/element.cpp
@@ -190,7 +190,7 @@ uint32_t AXLibGetWindowID(AXUIElementRef WindowRef)
 // NOTE(koekeishiya): Caller frees memory.
 char *AXLibGetWindowTitle(AXUIElementRef WindowRef)
 {
-    char *Result = strdup("<unknown>");
+    char *Result = NULL;
 
     CFStringRef WindowTitleRef = (CFStringRef) AXLibGetWindowProperty(WindowRef, kAXTitleAttribute);
     if(WindowTitleRef)
@@ -202,6 +202,11 @@ char *AXLibGetWindowTitle(AXUIElementRef WindowRef)
         {
             Result = WindowTitle;
         }
+    }
+
+    if(!Result)
+    {
+        Result = strdup("<unknown>");
     }
 
     return Result;

--- a/src/common/accessibility/window.h
+++ b/src/common/accessibility/window.h
@@ -30,10 +30,13 @@ struct macos_window
 };
 
 macos_window *AXLibConstructWindow(macos_application *Application, AXUIElementRef WindowRef);
+macos_window *AXLibCopyWindow(macos_window *Window);
 void AXLibDestroyWindow(macos_window *Window);
 
 bool AXLibIsWindowStandard(macos_window *Window);
 bool AXLibWindowHasRole(macos_window *Window, CFTypeRef Role);
+
+macos_window **AXLibWindowListForApplication(macos_application *Application);
 
 /* NOTE(koekeishiya): This is not a thing for now.
  * bool AXLibIsWindowCustom(macos_window *Window);

--- a/src/common/dispatch/workspace.h
+++ b/src/common/dispatch/workspace.h
@@ -1,14 +1,7 @@
 #ifndef CHUNKWM_COMMON_WS_H
 #define CHUNKWM_COMMON_WS_H
 
-#include <Carbon/Carbon.h>
-
-struct workspace_application_details
-{
-    char *ProcessName;
-    ProcessSerialNumber PSN;
-    pid_t PID;
-};
+#include <unistd.h>
 
 char *WorkspaceCopyProcessNameAndPolicy(pid_t PID, uint32_t *ProcessPolicy);
 char *WorkspaceCopyProcessName(pid_t PID);

--- a/src/common/dispatch/workspace.mm
+++ b/src/common/dispatch/workspace.mm
@@ -16,7 +16,7 @@ char *WorkspaceCopyProcessNameAndPolicy(pid_t PID, uint32_t *ProcessPolicy)
 
     if(!ProcessName)
     {
-        ProcessName = strdup("<Unknown>");
+        ProcessName = strdup("<unknown>");
     }
 
     return ProcessName;
@@ -37,7 +37,7 @@ char *WorkspaceCopyProcessName(pid_t PID)
 
     if(!ProcessName)
     {
-        ProcessName = strdup("<Unknown>");
+        ProcessName = strdup("<unknown>");
     }
 
     return ProcessName;

--- a/src/core/callback.cpp
+++ b/src/core/callback.cpp
@@ -1,6 +1,7 @@
 #include "callback.h"
 #include "plugin.h"
 #include "wqueue.h"
+#include "state.h"
 
 #include "dispatch/carbon.h"
 #include "dispatch/workspace.h"
@@ -9,7 +10,9 @@
 #include <stdio.h>
 #include <pthread.h>
 
-#define ProcessPluginList(plugin_export)                   \
+#define internal static
+
+#define ProcessPluginList(plugin_export, Context)          \
     plugin_list *List = BeginPluginList(plugin_export);    \
     for(plugin_list_iter It = List->begin();               \
         It != List->end();                                 \
@@ -17,11 +20,11 @@
     {                                                      \
         plugin *Plugin = It->first;                        \
         Plugin->Run(#plugin_export,                        \
-                    (char *) Event->Context);              \
+                    (char *) Context);                     \
     }                                                      \
     EndPluginList(plugin_export)
 
-#define ProcessPluginListThreaded(plugin_export)           \
+#define ProcessPluginListThreaded(plugin_export, Context)  \
     plugin_list *List = BeginPluginList(plugin_export);    \
     plugin_work WorkArray[List->size()];                   \
     int WorkCount = 0;                                     \
@@ -32,15 +35,13 @@
         plugin_work *Work = WorkArray + WorkCount++;       \
         Work->Plugin = It->first;                          \
         Work->Export = (char *) #plugin_export;            \
-        Work->Data = (char *) Event->Context;              \
+        Work->Data = (char *) Context;                     \
         AddWorkQueueEntry(&Queue,                          \
                           &PluginWorkCallback,             \
                           Work);                           \
     }                                                      \
     EndPluginList(plugin_export);                          \
     CompleteWorkQueue(&Queue)                              \
-
-#define internal static
 
 struct plugin_work
 {
@@ -78,33 +79,48 @@ void BeginCallbackThreads(int Count)
     }
 }
 
+internal bool
+IsProcessInteractive(carbon_application_details *Info)
+{
+    bool Result = ((!Info->ProcessBackground) &&
+                   (Info->ProcessPolicy != PROCESS_POLICY_LSBACKGROUND_ONLY));
+    return Result;
+}
+
 // NOTE(koekeishiya): Application-related callbacks.
 CHUNKWM_CALLBACK(Callback_ChunkWM_ApplicationLaunched)
 {
     carbon_application_details *Info =
         (carbon_application_details *) Event->Context;
-    printf("%d:%s launched\n", Info->PID, Info->ProcessName);
 
+    if(IsProcessInteractive(Info))
+    {
+        printf("%d:%s launched\n", Info->PID, Info->ProcessName);
+        macos_application *Application = ConstructAndAddApplication(Info->PSN, Info->PID, Info->ProcessName);
 #if 0
-    ProcessPluginList(chunkwm_export_application_launched);
+        ProcessPluginList(chunkwm_export_application_launched, Application);
 #else
-    ProcessPluginListThreaded(chunkwm_export_application_launched);
+        ProcessPluginListThreaded(chunkwm_export_application_launched, Application);
 #endif
-
-    EndCarbonApplicationDetails(Info);
+    }
 }
 
 CHUNKWM_CALLBACK(Callback_ChunkWM_ApplicationTerminated)
 {
     carbon_application_details *Info =
         (carbon_application_details *) Event->Context;
-    printf("%d:%s terminated\n", Info->PID, Info->ProcessName);
 
+    macos_application *Application = GetApplicationFromPID(Info->PID);
+    if(Application)
+    {
+        printf("%d:%s terminated\n", Info->PID, Info->ProcessName);
 #if 0
-    ProcessPluginList(chunkwm_export_application_terminated);
+        ProcessPluginList(chunkwm_export_application_terminated, Application);
 #else
-    ProcessPluginListThreaded(chunkwm_export_application_terminated);
+        ProcessPluginListThreaded(chunkwm_export_application_terminated, Application);
 #endif
+        RemoveAndDestroyApplication(Application);
+    }
 
     EndCarbonApplicationDetails(Info);
 }
@@ -113,13 +129,17 @@ CHUNKWM_CALLBACK(Callback_ChunkWM_ApplicationActivated)
 {
     workspace_application_details *Info =
         (workspace_application_details *) Event->Context;
-    printf("%d:%s activated\n", Info->PID, Info->ProcessName);
 
+    macos_application *Application = GetApplicationFromPID(Info->PID);
+    if(Application)
+    {
+        printf("%d:%s activated\n", Info->PID, Info->ProcessName);
 #if 0
-    ProcessPluginList(chunkwm_export_application_activated);
+        ProcessPluginList(chunkwm_export_application_activated, Application);
 #else
-    ProcessPluginListThreaded(chunkwm_export_application_activated);
+        ProcessPluginListThreaded(chunkwm_export_application_activated, Application);
 #endif
+    }
 
     EndWorkspaceApplicationDetails(Info);
 }
@@ -128,13 +148,17 @@ CHUNKWM_CALLBACK(Callback_ChunkWM_ApplicationDeactivated)
 {
     workspace_application_details *Info =
         (workspace_application_details *) Event->Context;
-    printf("%d:%s deactivated\n", Info->PID, Info->ProcessName);
 
+    macos_application *Application = GetApplicationFromPID(Info->PID);
+    if(Application)
+    {
+        printf("%d:%s deactivated\n", Info->PID, Info->ProcessName);
 #if 0
-    ProcessPluginList(chunkwm_export_application_deactivated);
+        ProcessPluginList(chunkwm_export_application_deactivated, Application);
 #else
-    ProcessPluginListThreaded(chunkwm_export_application_deactivated);
+        ProcessPluginListThreaded(chunkwm_export_application_deactivated, Application);
 #endif
+    }
 
     EndWorkspaceApplicationDetails(Info);
 }
@@ -143,13 +167,17 @@ CHUNKWM_CALLBACK(Callback_ChunkWM_ApplicationVisible)
 {
     workspace_application_details *Info =
         (workspace_application_details *) Event->Context;
-    printf("%d:%s visible\n", Info->PID, Info->ProcessName);
 
+    macos_application *Application = GetApplicationFromPID(Info->PID);
+    if(Application)
+    {
+        printf("%d:%s visible\n", Info->PID, Info->ProcessName);
 #if 0
-    ProcessPluginList(chunkwm_export_application_unhidden);
+        ProcessPluginList(chunkwm_export_application_unhidden, Application);
 #else
-    ProcessPluginListThreaded(chunkwm_export_application_unhidden);
+        ProcessPluginListThreaded(chunkwm_export_application_unhidden, Application);
 #endif
+    }
 
     EndWorkspaceApplicationDetails(Info);
 }
@@ -158,24 +186,33 @@ CHUNKWM_CALLBACK(Callback_ChunkWM_ApplicationHidden)
 {
     workspace_application_details *Info =
         (workspace_application_details *) Event->Context;
-    printf("%d:%s hidden\n", Info->PID, Info->ProcessName);
 
+    macos_application *Application = GetApplicationFromPID(Info->PID);
+    if(Application)
+    {
+        printf("%d:%s hidden\n", Info->PID, Info->ProcessName);
 #if 0
-    ProcessPluginList(chunkwm_export_application_hidden);
+        ProcessPluginList(chunkwm_export_application_hidden, Application);
 #else
-    ProcessPluginListThreaded(chunkwm_export_application_hidden);
+        ProcessPluginListThreaded(chunkwm_export_application_hidden, Application);
 #endif
+    }
 
     EndWorkspaceApplicationDetails(Info);
 }
 
 CHUNKWM_CALLBACK(Callback_ChunkWM_SpaceChanged)
 {
+    /* NOTE(koekeishiya): Applications that are not on our focused space fails to have their
+     * existing windows added to our windw collection. We must force update our collection on
+     * every space change. Windows that are already tracked is NOT added multiple times. */
+    UpdateWindowCollection();
+
     /* NOTE(koekeishiya): This event does not take an argument. */
 #if 0
-    ProcessPluginList(chunkwm_export_space_changed);
+    ProcessPluginList(chunkwm_export_space_changed, NULL);
 #else
-    ProcessPluginListThreaded(chunkwm_export_space_changed);
+    ProcessPluginListThreaded(chunkwm_export_space_changed, NULL);
 #endif
 }
 
@@ -185,11 +222,10 @@ CHUNKWM_CALLBACK(Callback_ChunkWM_DisplayAdded)
     CGDirectDisplayID *DisplayId
         = (CGDirectDisplayID *) Event->Context;
     printf("%d: display added\n", *DisplayId);
-
 #if 0
-    ProcessPluginList(chunkwm_export_display_added);
+    ProcessPluginList(chunkwm_export_display_added, DisplayId);
 #else
-    ProcessPluginListThreaded(chunkwm_export_display_added);
+    ProcessPluginListThreaded(chunkwm_export_display_added, DisplayId);
 #endif
 
     free(DisplayId);
@@ -200,11 +236,10 @@ CHUNKWM_CALLBACK(Callback_ChunkWM_DisplayRemoved)
     CGDirectDisplayID *DisplayId
         = (CGDirectDisplayID *) Event->Context;
     printf("%d: display removed\n", *DisplayId);
-
 #if 0
-    ProcessPluginList(chunkwm_export_display_removed);
+    ProcessPluginList(chunkwm_export_display_removed, DisplayId);
 #else
-    ProcessPluginListThreaded(chunkwm_export_display_removed);
+    ProcessPluginListThreaded(chunkwm_export_display_removed, DisplayId);
 #endif
 
     free(DisplayId);
@@ -215,11 +250,10 @@ CHUNKWM_CALLBACK(Callback_ChunkWM_DisplayMoved)
     CGDirectDisplayID *DisplayId
         = (CGDirectDisplayID *) Event->Context;
     printf("%d: display moved\n", *DisplayId);
-
 #if 0
-    ProcessPluginList(chunkwm_export_display_moved);
+    ProcessPluginList(chunkwm_export_display_moved, DisplayId);
 #else
-    ProcessPluginListThreaded(chunkwm_export_display_moved);
+    ProcessPluginListThreaded(chunkwm_export_display_moved, DisplayId);
 #endif
 
     free(DisplayId);
@@ -230,12 +264,10 @@ CHUNKWM_CALLBACK(Callback_ChunkWM_DisplayResized)
     CGDirectDisplayID *DisplayId
         = (CGDirectDisplayID *) Event->Context;
     printf("%d: display resolution changed\n", *DisplayId);
-
-
 #if 0
-    ProcessPluginList(chunkwm_export_display_resized);
+    ProcessPluginList(chunkwm_export_display_resized, DisplayId);
 #else
-    ProcessPluginListThreaded(chunkwm_export_display_resized);
+    ProcessPluginListThreaded(chunkwm_export_display_resized, DisplayId);
 #endif
 
     free(DisplayId);
@@ -244,4 +276,108 @@ CHUNKWM_CALLBACK(Callback_ChunkWM_DisplayResized)
 CHUNKWM_CALLBACK(Callback_ChunkWM_DisplayChanged)
 {
     /* NOTE(koekeishiya): This event does not take an argument. */
+}
+
+// NOTE(koekeishiya): Window-related callbacks
+CHUNKWM_CALLBACK(Callback_ChunkWM_WindowCreated)
+{
+    macos_window *Window = (macos_window *) Event->Context;
+    if(AddWindowToCollection(Window))
+    {
+        printf("%s:%s window created\n", Window->Owner->Name, Window->Name);
+#if 0
+        ProcessPluginList(chunkwm_export_window_created, Window);
+#else
+        ProcessPluginListThreaded(chunkwm_export_window_created, Window);
+#endif
+        /* NOTE(koekeishiya): When a new window is created, we incorrectly
+         * receive the kAXFocusedWindowChangedNotification first, We discard
+         * that notification and restore it when we have the window to work with. */
+        ConstructEvent(ChunkWM_WindowFocused, Window);
+    }
+    else
+    {
+        printf("%s:%s window is not destructible, ignore!\n", Window->Owner->Name, Window->Name);
+        AXLibRemoveObserverNotification(&Window->Owner->Observer, Window->Ref, kAXUIElementDestroyedNotification);
+        AXLibDestroyWindow(Window);
+    }
+}
+
+CHUNKWM_CALLBACK(Callback_ChunkWM_WindowDestroyed)
+{
+    macos_window *Window = (macos_window *) Event->Context;
+    printf("%s:%s window destroyed\n", Window->Owner->Name, Window->Name);
+#if 0
+    ProcessPluginList(chunkwm_export_window_destroyed, Window);
+#else
+    ProcessPluginListThreaded(chunkwm_export_window_destroyed, Window);
+#endif
+    RemoveWindowFromCollection(Window);
+    AXLibDestroyWindow(Window);
+}
+
+CHUNKWM_CALLBACK(Callback_ChunkWM_WindowFocused)
+{
+    macos_window *Window = (macos_window *) Event->Context;
+    printf("%s:%s window focused\n", Window->Owner->Name, Window->Name);
+#if 0
+    ProcessPluginList(chunkwm_export_window_focused, Window);
+#else
+    ProcessPluginListThreaded(chunkwm_export_window_focused, Window);
+#endif
+}
+
+CHUNKWM_CALLBACK(Callback_ChunkWM_WindowMoved)
+{
+    macos_window *Window = (macos_window *) Event->Context;
+    printf("%s:%s window moved\n", Window->Owner->Name, Window->Name);
+#if 0
+    ProcessPluginList(chunkwm_export_window_moved, Window);
+#else
+    ProcessPluginListThreaded(chunkwm_export_window_moved, Window);
+#endif
+}
+
+CHUNKWM_CALLBACK(Callback_ChunkWM_WindowResized)
+{
+    macos_window *Window = (macos_window *) Event->Context;
+    printf("%s:%s window resized\n", Window->Owner->Name, Window->Name);
+#if 0
+    ProcessPluginList(chunkwm_export_window_resized, Window);
+#else
+    ProcessPluginListThreaded(chunkwm_export_window_resized, Window);
+#endif
+}
+
+CHUNKWM_CALLBACK(Callback_ChunkWM_WindowMinimized)
+{
+    macos_window *Window = (macos_window *) Event->Context;
+    printf("%s:%s window minimized\n", Window->Owner->Name, Window->Name);
+#if 0
+    ProcessPluginList(chunkwm_export_window_minimized, Window);
+#else
+    ProcessPluginListThreaded(chunkwm_export_window_minimized, Window);
+#endif
+}
+
+CHUNKWM_CALLBACK(Callback_ChunkWM_WindowDeminimized)
+{
+    macos_window *Window = (macos_window *) Event->Context;
+    printf("%s:%s window deminimized\n", Window->Owner->Name, Window->Name);
+#if 0
+    ProcessPluginList(chunkwm_export_window_deminimized, Window);
+#else
+    ProcessPluginListThreaded(chunkwm_export_window_deminimized, Window);
+#endif
+}
+
+/* NOTE(koekeishiya): If a plugin has stored a pointer to our macos_window structs
+ * and tries to access the 'name' member outside of 'PLUGIN_MAIN_FUNC', there will
+ * be a race condition. Doing so is considered an error.. */
+CHUNKWM_CALLBACK(Callback_ChunkWM_WindowTitleChanged)
+{
+    macos_window *Window = (macos_window *) Event->Context;
+    UpdateWindowTitle(Window);
+
+    printf("%s:%s window title changed\n", Window->Owner->Name, Window->Name);
 }

--- a/src/core/chunkwm.mm
+++ b/src/core/chunkwm.mm
@@ -6,9 +6,15 @@
 #include "dispatch/display.h"
 #include "dispatch/event.h"
 
+#include "state.h"
 #include "callback.h"
 #include "plugin.h"
 #include "wqueue.h"
+
+#include "../common/accessibility/observer.cpp"
+#include "../common/accessibility/application.cpp"
+#include "../common/accessibility/window.cpp"
+#include "../common/accessibility/element.cpp"
 
 #include "../common/dispatch/carbon.cpp"
 #include "../common/dispatch/workspace.mm"
@@ -18,6 +24,7 @@
 #include "dispatch/event.cpp"
 #include "dispatch/display.cpp"
 
+#include "state.cpp"
 #include "callback.cpp"
 #include "plugin.cpp"
 #include "wqueue.cpp"
@@ -52,8 +59,19 @@ int main(int Count, char **Args)
 
         BeginPlugins();
 
-        StartEventLoop();
-        CFRunLoopRun();
+        if(InitState())
+        {
+            StartEventLoop();
+            CFRunLoopRun();
+        }
+        else
+        {
+            fprintf(stderr, "chunkwm: failed to initialize critical mutex! abort..\n");
+        }
+    }
+    else
+    {
+        fprintf(stderr, "chunkwm: failed to install carbon eventhandler! abort..\n");
     }
 
     return EXIT_SUCCESS;

--- a/src/core/dispatch/carbon.cpp
+++ b/src/core/dispatch/carbon.cpp
@@ -1,7 +1,9 @@
 #include "carbon.h"
 #include "event.h"
+
 #include <string.h>
 #include <unordered_map>
+
 #define internal static
 
 struct psn_hash {
@@ -31,21 +33,6 @@ typedef std::unordered_map<ProcessSerialNumber, carbon_application_details *, ps
  * application using GetProcessInformation and have to cache the information in advance.
  * */
 internal carbon_application_cache CarbonApplicationCache;
-
-internal carbon_application_details *
-CopyCarbonApplicationDetails(carbon_application_details *Info)
-{
-    carbon_application_details *Result =
-        (carbon_application_details *) malloc(sizeof(carbon_application_details));
-
-    Result->PID = Info->PID;
-    Result->PSN = Info->PSN;
-    Result->ProcessPolicy = Info->ProcessPolicy;
-    Result->ProcessBackground = Info->ProcessBackground;
-    Result->ProcessName = strdup(Info->ProcessName);
-
-    return Result;
-}
 
 internal carbon_application_details *
 SearchCarbonApplicationDetailsCache(ProcessSerialNumber PSN)
@@ -112,8 +99,7 @@ CarbonApplicationEventHandler(EventHandlerCallRef HandlerCallRef, EventRef Event
         case kEventAppLaunched:
         {
             carbon_application_details *Info = BeginCarbonApplicationDetails(PSN);
-            carbon_application_details *Copy = CopyCarbonApplicationDetails(Info);
-            CarbonApplicationCache[PSN] = Copy;
+            CarbonApplicationCache[PSN] = Info;
             ConstructEvent(ChunkWM_ApplicationLaunched, Info);
         } break;
         case kEventAppTerminated:

--- a/src/core/dispatch/carbon.h
+++ b/src/core/dispatch/carbon.h
@@ -14,6 +14,5 @@ struct carbon_event_handler
 
 bool BeginCarbonEventHandler(carbon_event_handler *Carbon);
 bool EndCarbonEventHandler(carbon_event_handler *Carbon);
-void EndCarbonApplicationDetails(carbon_application_details *Info);
 
 #endif

--- a/src/core/dispatch/event.h
+++ b/src/core/dispatch/event.h
@@ -24,6 +24,17 @@ extern CHUNKWM_CALLBACK(Callback_ChunkWM_DisplayChanged);
 
 extern CHUNKWM_CALLBACK(Callback_ChunkWM_SpaceChanged);
 
+extern CHUNKWM_CALLBACK(Callback_ChunkWM_WindowCreated);
+extern CHUNKWM_CALLBACK(Callback_ChunkWM_WindowDestroyed);
+extern CHUNKWM_CALLBACK(Callback_ChunkWM_WindowFocused);
+extern CHUNKWM_CALLBACK(Callback_ChunkWM_WindowMoved);
+extern CHUNKWM_CALLBACK(Callback_ChunkWM_WindowResized);
+extern CHUNKWM_CALLBACK(Callback_ChunkWM_WindowMinimized);
+extern CHUNKWM_CALLBACK(Callback_ChunkWM_WindowDeminimized);
+
+// NOTE(koekeishiya): This property is not exposed to plugins
+extern CHUNKWM_CALLBACK(Callback_ChunkWM_WindowTitleChanged);
+
 enum event_type
 {
     ChunkWM_ApplicationLaunched,
@@ -39,6 +50,17 @@ enum event_type
     ChunkWM_DisplayResized,
     ChunkWM_DisplayChanged,
     ChunkWM_SpaceChanged,
+
+    ChunkWM_WindowCreated,
+    ChunkWM_WindowDestroyed,
+    ChunkWM_WindowFocused,
+    ChunkWM_WindowMoved,
+    ChunkWM_WindowResized,
+    ChunkWM_WindowMinimized,
+    ChunkWM_WindowDeminimized,
+
+    // NOTE(koekeishiya): This property is not exposed to plugins
+    ChunkWM_WindowTitleChanged,
 };
 
 struct chunk_event

--- a/src/core/dispatch/workspace.h
+++ b/src/core/dispatch/workspace.h
@@ -1,7 +1,14 @@
 #ifndef CHUNKWM_OSX_WS_H
 #define CHUNKWM_OSX_WS_H
 
-#include "../../common/dispatch/workspace.h"
+#include <Carbon/Carbon.h>
+
+struct workspace_application_details
+{
+    char *ProcessName;
+    ProcessSerialNumber PSN;
+    pid_t PID;
+};
 
 void BeginSharedWorkspace();
 void EndWorkspaceApplicationDetails(workspace_application_details *Info);

--- a/src/core/dispatch/workspace.mm
+++ b/src/core/dispatch/workspace.mm
@@ -1,5 +1,6 @@
 #import <Cocoa/Cocoa.h>
-#import "workspace.h"
+
+#include "workspace.h"
 #include "event.h"
 
 #define internal static
@@ -33,7 +34,7 @@ BeginWorkspaceApplicationDetails(NSNotification *Notification)
     }
     else
     {
-        Info->ProcessName = strdup("<Unknown Name>");
+        Info->ProcessName = strdup("<unknown>");
     }
 
     return Info;

--- a/src/core/state.cpp
+++ b/src/core/state.cpp
@@ -1,0 +1,318 @@
+#include "state.h"
+
+#include "dispatch/event.h"
+
+#include "../common/accessibility/application.h"
+#include "../common/accessibility/window.h"
+#include "../common/accessibility/element.h"
+
+#include <pthread.h>
+
+#include <map>
+#include <vector>
+
+#define internal static
+
+typedef std::map<pid_t, macos_application *> macos_application_map;
+typedef macos_application_map::iterator macos_application_map_it;
+
+typedef std::map<uint32_t, macos_window *> macos_window_map;
+typedef macos_window_map::iterator macos_window_map_it;
+
+internal macos_application_map Applications;
+
+internal macos_window_map Windows;
+internal pthread_mutex_t WindowsLock;
+
+/* NOTE(koekeishiya): We need a way to retrieve AXUIElementRef from a CGWindowID.
+ * There is no way to do this, without caching AXUIElementRef references.
+ * Here we perform a lookup of macos_window structs. */
+internal macos_window *
+GetWindowByID(uint32_t Id)
+{
+    pthread_mutex_lock(&WindowsLock);
+    macos_window_map_it It = Windows.find(Id);
+    macos_window *Result = (It != Windows.end()) ? It->second : NULL;
+    pthread_mutex_unlock(&WindowsLock);
+
+    return Result;
+}
+
+/* NOTE(koekeishiya): Caller is responsible for making sure that the window is not a dupe.
+ * If the window can not be added to the collection, caller is responsible for memory. */
+bool AddWindowToCollection(macos_window *Window)
+{
+    // NOTE(koekeishiya): A window with id 0 is never valid!
+    if(Window->Id == 0)
+    {
+        return false;
+    }
+
+    AXError Success = AXLibAddObserverNotification(&Window->Owner->Observer,
+                                                   Window->Ref,
+                                                   kAXUIElementDestroyedNotification,
+                                                   Window);
+    bool Result = (Success == kAXErrorSuccess);
+    if(Result)
+    {
+        pthread_mutex_lock(&WindowsLock);
+        Windows[Window->Id] = Window;
+        pthread_mutex_unlock(&WindowsLock);
+    }
+
+    return Result;
+}
+
+// NOTE(koekeishiya): Caller is responsible for passing a valid window!
+void RemoveWindowFromCollection(macos_window *Window)
+{
+    pthread_mutex_lock(&WindowsLock);
+    Windows.erase(Window->Id);
+    pthread_mutex_unlock(&WindowsLock);
+
+    AXLibRemoveObserverNotification(&Window->Owner->Observer, Window->Ref, kAXUIElementDestroyedNotification);
+}
+
+// NOTE(koekeishiya): Caller is responsible for passing a valid window!
+void UpdateWindowTitle(macos_window *Window)
+{
+    if(Window->Name)
+    {
+        free(Window->Name);
+    }
+
+    Window->Name = AXLibGetWindowTitle(Window->Ref);
+}
+
+/* NOTE(koekeishiya): Construct macos_windows for an application and add them to our window-collection.
+ * If a window is not added to our collection for any reason, we release the memory. */
+internal void
+AddApplicationWindowsToCollection(macos_application *Application)
+{
+    macos_window **WindowList = AXLibWindowListForApplication(Application);
+    if(WindowList)
+    {
+        macos_window *Window = NULL;
+        macos_window **List = WindowList;
+
+        while((Window = *List++))
+        {
+            if(GetWindowByID(Window->Id))
+            {
+                AXLibDestroyWindow(Window);
+            }
+            else
+            {
+                if(!AddWindowToCollection(Window))
+                {
+                    printf("%s:%s is not destructible, ignore!\n", Window->Owner->Name, Window->Name);
+                    AXLibDestroyWindow(Window);
+                }
+            }
+        }
+
+        free(WindowList);
+    }
+}
+
+// NOTE(koekeishiya): We need a way to retrieve a macos_application * by PID
+macos_application *GetApplicationFromPID(pid_t PID)
+{
+    macos_application *Result = NULL;
+
+    macos_application_map_it It = Applications.find(PID);
+    if(It != Applications.end())
+    {
+        Result = It->second;
+    }
+
+    return Result;
+}
+
+internal void
+AddApplication(macos_application *Application)
+{
+    macos_application_map_it It = Applications.find(Application->PID);
+    if(It == Applications.end())
+    {
+        Applications[Application->PID] = Application;
+    }
+}
+
+internal
+OBSERVER_CALLBACK(ApplicationCallback)
+{
+    macos_application *Application = (macos_application *) Reference;
+
+    if(CFEqual(Notification, kAXWindowCreatedNotification))
+    {
+        macos_window *Window = AXLibConstructWindow(Application, Element);
+        ConstructEvent(ChunkWM_WindowCreated, Window);
+    }
+    else if(CFEqual(Notification, kAXUIElementDestroyedNotification))
+    {
+        /* NOTE(koekeishiya): If this is an actual window, it should be associated
+         * with a valid CGWindowID. HOWEVER, because the window in question has been
+         * destroyed. We are unable to utilize this window reference with the AX API.
+         *
+         * The 'CFEqual()' function can still be used to compare this AXUIElementRef
+         * with any existing window refs that we may have. There are a couple of ways
+         * we can use to track if an actual window is closed.
+         *
+         *   a) Store all window AXUIElementRefs in a local cache that we update upon
+         *      creation and removal. Requires unsorted container with custom comparator
+         *      that uses 'CFEqual()' to match AXUIElementRefs.
+         *
+         *   b) Instead of tracking 'kAXUIElementDestroyedNotification' for an application,
+         *      we have to register this notification separately for every window created.
+         *      By doing this, we can pass our own data containing the information necessary
+         *      to properly identify and report which window was destroyed.
+         *
+         * At the very least, we need to know the windowid of the destroyed window. */
+
+        /* NOTE(koekeishiya): Option 'b' has been implemented. Leaving note for future reference. */
+
+        macos_window *Window = (macos_window *) Reference;
+        ConstructEvent(ChunkWM_WindowDestroyed, Window);
+    }
+    else if(CFEqual(Notification, kAXFocusedWindowChangedNotification))
+    {
+        uint32_t WindowId = AXLibGetWindowID(Element);
+        macos_window *Window = GetWindowByID(WindowId);
+        if(Window)
+        {
+            ConstructEvent(ChunkWM_WindowFocused, Window);
+        }
+    }
+    else if(CFEqual(Notification, kAXWindowMovedNotification))
+    {
+        uint32_t WindowId = AXLibGetWindowID(Element);
+        macos_window *Window = GetWindowByID(WindowId);
+        if(Window)
+        {
+            ConstructEvent(ChunkWM_WindowMoved, Window);
+        }
+    }
+    else if(CFEqual(Notification, kAXWindowResizedNotification))
+    {
+        uint32_t WindowId = AXLibGetWindowID(Element);
+        macos_window *Window = GetWindowByID(WindowId);
+        if(Window)
+        {
+            ConstructEvent(ChunkWM_WindowResized, Window);
+        }
+    }
+    else if(CFEqual(Notification, kAXWindowMiniaturizedNotification))
+    {
+        uint32_t WindowId = AXLibGetWindowID(Element);
+        macos_window *Window = GetWindowByID(WindowId);
+        if(Window)
+        {
+            ConstructEvent(ChunkWM_WindowMinimized, Window);
+        }
+    }
+    else if(CFEqual(Notification, kAXWindowDeminiaturizedNotification))
+    {
+        uint32_t WindowId = AXLibGetWindowID(Element);
+        macos_window *Window = GetWindowByID(WindowId);
+        if(Window)
+        {
+            ConstructEvent(ChunkWM_WindowDeminimized, Window);
+        }
+    }
+    else if(CFEqual(Notification, kAXTitleChangedNotification))
+    {
+        uint32_t WindowId = AXLibGetWindowID(Element);
+        macos_window *Window = GetWindowByID(WindowId);
+        if(Window)
+        {
+            ConstructEvent(ChunkWM_WindowTitleChanged, Window);
+        }
+    }
+}
+
+#define MICROSEC_PER_SEC 1e6
+macos_application *ConstructAndAddApplication(ProcessSerialNumber PSN, pid_t PID, char *ProcessName)
+{
+    macos_application *Application = AXLibConstructApplication(PSN, PID, ProcessName);
+    AddApplication(Application);
+
+    /* NOTE(koekeishiya): We need to wait for some amount of time before we can try to
+     * observe the launched application. The time to wait depends on how long the
+     * application in question takes to finish. Half a second is good enough for
+     * most applications so we 'usleep()' as a temporary fix for now, but we need a way
+     * to properly defer the creation of observers for applications that require more time.
+     *
+     * We cannot simply defer the creation automatically using dispatch_after, because
+     * there is simply no way to remove a dispatched event once it has been created.
+     * We need a way to tell a dispatched event to NOT execute and be rendered invalid,
+     * because some applications only live for a very very short amount of time.
+     * The dispatched event will then be triggered after a potential 'terminated' event
+     * has been received, in which the application reference has been freed.
+     *
+     * Passing an invalid reference to the AXObserver API does not simply trigger an error,
+     * but causes a full on segmentation fault. */
+
+    usleep(0.5 * MICROSEC_PER_SEC);
+    if(AXLibAddApplicationObserver(Application, ApplicationCallback))
+    {
+        printf("%d:%s registered window notifications\n", Application->PID, Application->Name);
+    }
+    else
+    {
+        printf("%d:%s could not register window notifications!!!\n", Application->PID, Application->Name);
+        printf("%d:%s could not register window notifications!!!\n", Application->PID, Application->Name);
+        printf("%d:%s could not register window notifications!!!\n", Application->PID, Application->Name);
+    }
+
+    // NOTE(koekeishiya): An application can have multiple windows when it spawns.
+    // We need to track all of these.
+    AddApplicationWindowsToCollection(Application);
+
+    return Application;
+}
+
+void RemoveAndDestroyApplication(macos_application *Application)
+{
+    macos_application_map_it It = Applications.find(Application->PID);
+    if(It != Applications.end())
+    {
+        Applications.erase(It);
+    }
+
+    AXLibDestroyApplication(Application);
+}
+
+void UpdateWindowCollection()
+{
+    for(macos_application_map_it It = Applications.begin();
+        It != Applications.end();
+        ++It)
+    {
+        macos_application *Application = It->second;
+        AddApplicationWindowsToCollection(Application);
+    }
+}
+
+// NOTE(koekeishiya): This function is only supposed to be called by our chunkwm main function
+bool InitState()
+{
+    bool Result = pthread_mutex_init(&WindowsLock, NULL) == 0;
+    if(Result)
+    {
+        uint32_t ProcessPolicy = Process_Policy_Regular | Process_Policy_LSUIElement;
+        std::vector<macos_application *> RunningApplications = AXLibRunningProcesses(ProcessPolicy);
+
+        for(size_t Index = 0;
+            Index < RunningApplications.size();
+            ++Index)
+        {
+            macos_application *Application = RunningApplications[Index];
+            AddApplication(Application);
+            AXLibAddApplicationObserver(Application, ApplicationCallback);
+            AddApplicationWindowsToCollection(Application);
+        }
+    }
+
+    return Result;
+}

--- a/src/core/state.h
+++ b/src/core/state.h
@@ -1,0 +1,20 @@
+#ifndef CHUNKWM_CORE_STATE_H
+#define CHUNKWM_CORE_STATE_H
+
+#include <Carbon/Carbon.h>
+
+struct macos_window;
+bool AddWindowToCollection(macos_window *Window);
+void RemoveWindowFromCollection(macos_window *Window);
+void UpdateWindowCollection();
+
+void UpdateWindowTitle(macos_window *Window);
+
+struct macos_application;
+macos_application *GetApplicationFromPID(pid_t PID);
+macos_application *ConstructAndAddApplication(ProcessSerialNumber PSN, pid_t PID, char *ProcessName);
+void RemoveAndDestroyApplication(macos_application *Application);
+
+bool InitState();
+
+#endif

--- a/src/plugins/border/makefile
+++ b/src/plugins/border/makefile
@@ -1,11 +1,8 @@
 BUILD_FLAGS		= -O0 -g -std=c++11 -Wall
 BUILD_PATH		= ./../../../plugins
 SRC				= ./plugin.cpp ./overlay.mm \
-				  ./../../common/accessibility/application.cpp \
-				  ./../../common/accessibility/element.cpp \
-				  ./../../common/accessibility/observer.cpp \
-				  ./../../common/dispatch/carbon.cpp \
-				  ./../../common/dispatch/workspace.mm
+				  ./../../common/accessibility/window.cpp \
+				  ./../../common/accessibility/element.cpp
 BINS			= $(BUILD_PATH)/border.so
 LINK			= -shared -fPIC -framework Carbon -framework Cocoa -framework ApplicationServices
 

--- a/src/plugins/template/makefile
+++ b/src/plugins/template/makefile
@@ -2,7 +2,7 @@ BUILD_FLAGS		= -O0 -g -std=c++11 -Wall
 BUILD_PATH		= ./../../../plugins
 SRC				= ./plugin.cpp
 BINS			= $(BUILD_PATH)/template.so
-LINK			= -shared -fPIC -framework Carbon -framework ApplicationServices
+LINK			= -shared -fPIC -framework Carbon -framework Cocoa -framework ApplicationServices
 
 all: $(BINS)
 

--- a/src/plugins/template/plugin.cpp
+++ b/src/plugins/template/plugin.cpp
@@ -3,7 +3,7 @@
 #include <string.h>
 
 #include "../../api/plugin_api.h"
-#include "../../common/dispatch/carbon.h"
+#include "../../common/accessibility/application.h"
 
 inline bool
 StringsAreEqual(const char *A, const char *B)
@@ -22,18 +22,14 @@ PLUGIN_MAIN_FUNC(PluginMain)
 {
     if(StringsAreEqual(Node, "chunkwm_export_application_launched"))
     {
-        carbon_application_details *Info =
-            (carbon_application_details *) Data;
-
-        printf("    plugin template: launched: '%s'\n", Info->ProcessName);
+        macos_application *Application = (macos_application *) Data;
+        printf("    plugin template: launched: '%s'\n", Application->Name);
         return true;
     }
     else if(StringsAreEqual(Node, "chunkwm_export_application_terminated"))
     {
-        carbon_application_details *Info =
-            (carbon_application_details *) Data;
-
-        printf("    plugin template: terminated: '%s'\n", Info->ProcessName);
+        macos_application *Application = (macos_application *) Data;
+        printf("    plugin template: terminated: '%s'\n", Application->Name);
         return true;
     }
 

--- a/src/plugins/tiling/makefile
+++ b/src/plugins/tiling/makefile
@@ -7,9 +7,7 @@ SRC				= ./plugin.cpp ./node.cpp ./region.cpp \
 				  ./../../common/accessibility/element.cpp \
 				  ./../../common/accessibility/observer.cpp \
 				  ./../../common/dispatch/carbon.cpp \
-				  ./../../common/dispatch/workspace.mm \
-				  ./../../common/dispatch/cgeventtap.cpp \
-				  ./../../common/ipc/daemon.cpp
+				  ./../../common/dispatch/workspace.mm
 BINS			= $(BUILD_PATH)/tiling.so
 LINK			= -shared -fPIC -framework Carbon -framework Cocoa -framework ApplicationServices
 


### PR DESCRIPTION
**chunkwm** now tracks all running applications and their windows.

This allows for plugins to subscribe directly to window events, and they do not have to deal with the Accessibility Observer API at all.

See #10 for more.

Requires some code refactoring and API revise before merge. 