### PR TITLE
Adding query for active monitor's desktops

### DIFF
--- a/src/common/accessibility/display.h
+++ b/src/common/accessibility/display.h
@@ -56,6 +56,7 @@ macos_display **AXLibDisplayList(unsigned *Count);
 
 CGSSpaceID AXLibActiveCGSSpaceID(CFStringRef DisplayRef);
 macos_space *AXLibActiveSpace(CFStringRef DisplayRef);
+macos_space **AXLibGetSpacesForDisplay(CFStringRef DisplayRef);
 bool AXLibActiveSpace(macos_space **Space);
 void AXLibDestroySpace(macos_space *Space);
 

--- a/src/common/accessibility/display.mm
+++ b/src/common/accessibility/display.mm
@@ -12,6 +12,7 @@ extern "C" CGSConnectionID _CGSDefaultConnection(void);
 extern "C" CFDictionaryRef CGSSpaceCopyValues(CGSConnectionID Connection, CGSSpaceID SpaceId);
 extern "C" CGSSpaceType CGSSpaceGetType(CGSConnectionID Connection, CGSSpaceID SpaceId);
 extern "C" CFArrayRef CGSCopyManagedDisplaySpaces(const CGSConnectionID Connection);
+extern "C" CFArrayRef CGSCopySpaces(CGSConnectionID Connection, CGSSpaceSelector Type);
 extern "C" CFArrayRef CGSCopySpacesForWindows(CGSConnectionID Connection, CGSSpaceSelector Type, CFArrayRef Windows);
 extern "C" void CGSRemoveWindowsFromSpaces(CGSConnectionID Connection, CFArrayRef Windows, CFArrayRef Spaces);
 extern "C" void CGSAddWindowsToSpaces(CGSConnectionID Connection, CFArrayRef Windows, CFArrayRef Spaces);
@@ -318,6 +319,62 @@ macos_space *AXLibActiveSpace(CFStringRef DisplayRef)
 
     macos_space *Space = AXLibConstructSpace(SpaceRef, SpaceId, SpaceType);
     return Space;
+}
+
+/* NOTE(kalenanson): Return a list of spaces for the diaplay indicated.
+* The list is terminated by a null-pointer and can be iterated in the following way:
+*
+*     macos_space *Space, **List, **Spaces;
+*     List = Spaces = AXLibSpacesForWindow(Window->Id);
+*     while((Space = *List++)) { ..; AXLibDestroySpace(Space); }
+*     free(Spaces);
+*/
+macos_space **
+AXLibGetSpacesForDisplay(CFStringRef DisplayRef)
+{
+	ASSERT(DisplayRef);
+	macos_space **Result = NULL;
+	int NumberOfSpaces;
+	CFArrayRef Spaces = NULL;
+
+    Spaces = CGSCopySpaces(CGSDefaultConnection, kCGSSpaceAll);
+
+	if(Spaces != NULL)
+	{
+		NumberOfSpaces = CFArrayGetCount(Spaces);
+	}
+	else
+	{
+		NumberOfSpaces = 0;
+	}
+
+    if(NumberOfSpaces)
+    {
+        Result = (macos_space **) malloc(sizeof(macos_space *) * (NumberOfSpaces + 1));
+
+        for(int Index = 0;
+            Index < NumberOfSpaces;
+            ++Index)
+        {
+            NSNumber *Id = (__bridge NSNumber *) CFArrayGetValueAtIndex(Spaces, Index);
+            CGSSpaceID SpaceId = [Id intValue];
+
+            CFDictionaryRef SpaceCFDictionary = CGSSpaceCopyValues(CGSDefaultConnection, SpaceId);
+            NSDictionary *SpaceDictionary = (__bridge NSDictionary *) SpaceCFDictionary;
+
+            CGSSpaceType SpaceType = [SpaceDictionary[@"type"] intValue];
+            CFStringRef SpaceRef = (__bridge CFStringRef) [[NSString alloc] initWithString:SpaceDictionary[@"uuid"]];
+
+            macos_space *Space = AXLibConstructSpace(SpaceRef, SpaceId, SpaceType);
+            Result[Index] = Space;
+
+            CFRelease(SpaceCFDictionary);
+        }
+
+        Result[NumberOfSpaces] = NULL;
+        CFRelease(Spaces);
+    }
+    return Result;
 }
 
 /* NOTE(koekeishiya): Construct a macos_space representing the active space for the

--- a/src/plugins/tiling/README.md
+++ b/src/plugins/tiling/README.md
@@ -59,6 +59,7 @@
       * [query list of windows on focused desktop](#query-list-of-windows-on-focused-desktop)
   * [query monitor related](#query-monitor-related)
       * [query focused monitor](#query-focused-monitor-id)
+	  * [query focused monitor desktops](#query-focused-monitor-desktops)
 
 ---
 
@@ -398,4 +399,10 @@
 ##### query focused monitor id
 
     chunkc tiling::query --monitor id
-    short flag: d
+    short flag: m
+
+##### query-focused-monitor-desktops
+
+	chunkc tiling::query --monitor desktops
+	short flag: m
+	desc: outputs the list of desktops for the focused monitor

--- a/src/plugins/tiling/config.cpp
+++ b/src/plugins/tiling/config.cpp
@@ -599,7 +599,8 @@ ParseQueryCommand(const char *Message, command *Chain)
             } break;
             case 'm':
             {
-                if(StringEquals(optarg, "id"))
+                if((StringEquals(optarg, "id")) ||
+                   (StringEquals(optarg, "desktops")))
                 {
                     command *Entry = ConstructCommand(Option, optarg);
                     Command->Next = Entry;

--- a/src/plugins/tiling/controller.cpp
+++ b/src/plugins/tiling/controller.cpp
@@ -2309,10 +2309,84 @@ out:
     WriteToSocket(Message, SockFD);
 }
 
+internal inline void
+QueryFocusedMonitorSpaces(int SockFD)
+{
+    char Message[512], SpaceId[512];
+    CFStringRef DisplayRef;
+	unsigned ThisMonitor, MonitorId, DesktopId;
+    bool Success, Room;
+	macos_space *Space, **SpacesForWindow, **List;
+	size_t size;
+
+	Success = AXLibActiveSpace(&Space);
+    if(!Success)
+    {
+        snprintf(Message, sizeof(Message), "?");
+		DisplayRef = NULL;
+        goto out;
+    }
+
+	Success = AXLibCGSSpaceIDToDesktopID(Space->Id, &ThisMonitor, NULL);
+    ASSERT(Success);
+
+	DisplayRef = AXLibGetDisplayIdentifierFromArrangement(ThisMonitor);
+
+	SpacesForWindow = List = AXLibGetSpacesForDisplay(DisplayRef);
+	if (SpacesForWindow != NULL)
+	{
+		Room = true;
+		while((Space = *List++))
+		{
+			if(Space->Type == kCGSSpaceUser && Room)
+		    {
+				Success = AXLibCGSSpaceIDToDesktopID(Space->Id, &MonitorId, &DesktopId);
+			    ASSERT(Success);
+				if (MonitorId == ThisMonitor)
+				{
+					snprintf(SpaceId, sizeof(SpaceId),
+						"%d:%d ",
+						(ThisMonitor + 1),
+						DesktopId
+					);
+					size = strlcat(Message, SpaceId, sizeof (Message));
+					if (size == 512)
+					{
+						/*
+						 * We have reached the limit of the message buffer,
+						 * signal that there is no more room in the buffer, but
+						 * continue the while loop to free the contents of the
+						 * Space array and then end gracefully
+						 */
+						Message[size] = '\x0';
+						Room = false;
+					}
+				}
+			}
+			AXLibDestroySpace(Space);
+		}
+	    free(SpacesForWindow);
+	}
+	else
+	{
+		snprintf(Message, sizeof(Message), "?");
+	}
+out:
+	if(DisplayRef != NULL)
+	{
+		CFRelease(DisplayRef);
+	}
+    WriteToSocket(Message, SockFD);
+}
+
 void QueryMonitor(char *Op, int SockFD)
 {
     if(StringEquals(Op, "id"))
     {
         QueryFocusedMonitor(SockFD);
     }
+	else if(StringEquals(Op, "desktops"))
+	{
+		QueryFocusedMonitorSpaces(SockFD);
+	}
 }


### PR DESCRIPTION
Provides a way to query `chunkc` for the collection of destops for the currently active monitor.

Response is in the format:

    chunkc tiling::query --monitor desktops
    2:13 2:8 2:11 2:10 2:12 2:9

Where the list of desktops is `monitorID:desktopID` space deliniated.

The addition of the monitor id to the output saves an additional request to `chunkc` for this information. This format fit my use case, but I would not object to the return from this query being changed to omit the monitor ID.