### PR TITLE
Fix menubar height

### DIFF
--- a/src/plugins/tiling/region.cpp
+++ b/src/plugins/tiling/region.cpp
@@ -19,7 +19,7 @@ region CGRectToRegion(CGRect Rect)
     return Result;
 }
 
-#define OSX_MENU_BAR_HEIGHT 20.0f
+#define OSX_MENU_BAR_HEIGHT 22.0f
 void ConstrainRegion(CFStringRef DisplayRef, region *Region)
 {
     // NOTE(koekeishiya): Automatically adjust padding to account for osx menubar status.


### PR DESCRIPTION
macOS menubar height is actually 22pt, not 20pt as assumed by chunkwm.

I verified this by checking `NSApplication.shared.mainMenu?.menuBarHeight` and by counting pixels.

If no main menu is available, the value can also be verified like this:
```swift
if let screen = NSScreen.main {
    let height = screen.frame.height - screen.visibleFrame.height - screen.visibleFrame.origin.y
}
```