### PR TITLE
Add window-specific rules for the border plugin (#128).

### DIFF
--- a/src/plugins/border/plugin.mm
+++ b/src/plugins/border/plugin.mm
@@ -405,8 +405,6 @@ CommandHandler(void *Data)
 
         if(!RuleUpdated)
         {
-            // window_rule *Result = (window_rule *) malloc(sizeof(window_rule));
-            // memcpy(Result, WindowRule, sizeof(window_rule));
             WindowRules.push_back(WindowRule);
         }
 


### PR DESCRIPTION
This pull request adds rules for the border plugin to clear the border or change the border color for specific applications. This fixes issue #128.

Syntax (my proposal, kind of similar to tiling rules):

`chunkc border::rule --owner Spotify --color 0xff1db954 --border 1`.