### PR TITLE
monitors incorrectly identified as the same

### DIFF
--- a/src/plugins/tiling/controller.cpp
+++ b/src/plugins/tiling/controller.cpp
@@ -1580,13 +1580,13 @@ void SendWindowToMonitor(char *Op)
         goto space_free;
     }
 
-    if (DestinationMonitor == SourceMonitor) {
-        // NOTE(koekeishiya): Convert 0-indexed back to 1-index when printng error to user.
-        c_log(C_LOG_LEVEL_WARN,
-              "invalid destination monitor specified, source monitor and destination '%d' are the same!\n",
-              DestinationMonitor + 1);
-        goto space_free;
-    }
+    // if (DestinationMonitor == SourceMonitor) {
+    //     // NOTE(koekeishiya): Convert 0-indexed back to 1-index when printng error to user.
+    //     c_log(C_LOG_LEVEL_WARN,
+    //           "invalid destination monitor specified, source monitor and destination '%d' are the same!\n",
+    //           DestinationMonitor + 1);
+    //     goto space_free;
+    // }
 
     DestinationMonitorRef = AXLibGetDisplayIdentifierFromArrangement(DestinationMonitor);
     if (!DestinationMonitorRef) {
@@ -1731,12 +1731,12 @@ void FocusMonitor(char *Op)
         goto space_free;
     }
 
-    if (DestinationMonitor == SourceMonitor) {
-        c_log(C_LOG_LEVEL_WARN,
-              "invalid destination monitor specified, source monitor and destination '%d' are the same!\n",
-              DestinationMonitor + 1);
-        goto space_free;
-    }
+    // if (DestinationMonitor == SourceMonitor) {
+    //     c_log(C_LOG_LEVEL_WARN,
+    //           "invalid destination monitor specified, source monitor and destination '%d' are the same!\n",
+    //           DestinationMonitor + 1);
+    //     goto space_free;
+    // }
 
     switch (Operation) {
     case -1: {


### PR DESCRIPTION
Running into a bit of an odd one.  Sometimes the monitor switching, or window sending, code identifies two of my monitors as the same monitor.  Currently this is happening in a 3-monitor setup in a lower-case R shape.  Two on top of one that is below the left of the top two.  It consistently happens when trying to switch between the lower monitor and the right monitor, either direction, but works from the middle one.  When the checks for identical source and destination monitor are commented out, both commands work from all monitors again, although one of the monitors still gets left out of the monitor next/previous cycle.

I realize this probably isn't the right way to fix it, but if you can point me in the direction of the right way I wouldn't mind contributing a more appropriate fix.