### PR TITLE
Add new flag to skip tiling rule evaluation for window title based rules

### DIFF
--- a/src/plugins/tiling/README.md
+++ b/src/plugins/tiling/README.md
@@ -390,9 +390,10 @@ See the following sections for how to retrieve information about an open window:
 | --state    | -s         | native-fullscreen  | automatically enter native-fullscreen  |
 | --desktop  | -d         | index              | send window to desktop                 |
 
-| modifiers        | short flag | affected property | description                          |
-|------------------|:----------:|:-----------------:|:------------------------------------:|
-| --follow-desktop | -D         | desktop           | follow focus to the assigned desktop |
+| modifiers              | short flag | affected property | description                                  |
+|------------------------|:----------:|:-----------------:|:--------------------------------------------:|
+| --follow-desktop       | -D         | desktop           | follow focus to the assigned desktop         |
+| --ignore-title-updates | -i         | state             | rule is not evaluated on window title update |
 
 ##### sample rules
 

--- a/src/plugins/tiling/config.cpp
+++ b/src/plugins/tiling/config.cpp
@@ -595,6 +595,7 @@ ParseRuleCommand(const char *Message, window_rule *Rule)
         { "state", required_argument, NULL, 's' },
         { "desktop", required_argument, NULL, 'd' },
         { "follow-desktop", no_argument, NULL, 'D' },
+        { "ignore-title-updates", no_argument, NULL, 'i' },
         { NULL, 0, NULL, 0 }
     };
 
@@ -633,6 +634,9 @@ ParseRuleCommand(const char *Message, window_rule *Rule)
         } break;
         case 'D': {
             Rule->FollowDesktop = true;
+        } break;
+        case 'i': {
+            Rule->IgnoreTitleUpdates = true;
         } break;
         case '?': {
             Success = false;

--- a/src/plugins/tiling/rule.cpp
+++ b/src/plugins/tiling/rule.cpp
@@ -130,7 +130,9 @@ void ApplyRulesForWindowOnTitleChanged(macos_window *Window)
     for (size_t Index = 0; Index < WindowRules.size(); ++Index) {
         window_rule *Rule = WindowRules[Index];
         if (Rule->Name || Rule->Except) {
-            ApplyWindowRule(Window, Rule);
+            if (!Rule->IgnoreTitleUpdates) {
+                ApplyWindowRule(Window, Rule);
+            }
         }
     }
 }

--- a/src/plugins/tiling/rule.h
+++ b/src/plugins/tiling/rule.h
@@ -19,6 +19,7 @@ struct window_rule
     char *State;
     char *Desktop;
     bool FollowDesktop;
+    bool IgnoreTitleUpdates;
 };
 
 void AddWindowRule(window_rule *Rule);


### PR DESCRIPTION
An alternative solution to https://github.com/koekeishiya/chunkwm/issues/408.

This introduces a new flag that allows tiling rules based on window titles to be skipped for evaluation when the window title changes.