### PR TITLE
Add tiling rule to send window to monitor

### DIFF
--- a/src/plugins/tiling/README.md
+++ b/src/plugins/tiling/README.md
@@ -431,19 +431,21 @@ See the following sections for how to retrieve information about an open window:
 | --state       | -s         | sticky                       | show on all desktops (implicit float)   |
 | --state       | -s         | native-fullscreen            | automatically enter native-fullscreen   |
 | --desktop     | -d         | mission-control index        | send window to desktop                  |
+| --monitor     | -m         | monitor index                | send window to monitor                  |
 | --level       | -l         | integer (see link above)     | set window level based on the given key |
 | --alpha       | -a         | floating-point (0 <= a <= 1) | set window alpha                        |
 | --grid-layout | -g         | same as grid-layout command  | set window alpha                        |
 
 | modifiers        | short flag | affected property | description                          |
 |------------------|:----------:|:-----------------:|:------------------------------------:|
-| --follow-desktop | -D         | desktop           | follow focus to the assigned desktop |
+| --follow-desktop | -D         | desktop, monitor  | follow focus to the assigned desktop |
 
 ##### sample rules
 
     chunkc tiling::rule --owner \"System Preferences\" --subrole AXStandardWindow --state tile
     chunkc tiling::rule --owner Finder --name Copy --state float
     chunkc tiling::rule --owner Spotify --desktop 5 --follow-desktop
+    chunkc tiling::rule --owner Messages --monitor 2 --follow-desktop
     chunkc tiling::rule --owner mpv --state sticky --alpha 0.65 --grid-layout 5:5:4:0:1:1
     chunkc tiling::rule --owner Terminal --state sticky --level 3 --grid-layout 1:1:0:0:1:1
 

--- a/src/plugins/tiling/config.cpp
+++ b/src/plugins/tiling/config.cpp
@@ -638,6 +638,7 @@ ParseRuleCommand(const char *Message, window_rule *Rule)
         { "except", required_argument, NULL, 'e' },
         { "state", required_argument, NULL, 's' },
         { "desktop", required_argument, NULL, 'd' },
+        { "monitor", required_argument, NULL, 'm' },
         { "follow-desktop", no_argument, NULL, 'D' },
         { "level", required_argument, NULL, 'l' },
         { "alpha", required_argument, NULL, 'a' },
@@ -676,6 +677,10 @@ ParseRuleCommand(const char *Message, window_rule *Rule)
         } break;
         case 'd': {
             Rule->Desktop = strdup(optarg);
+            HasProperty = true;
+        } break;
+        case 'm': {
+            Rule->Monitor = strdup(optarg);
             HasProperty = true;
         } break;
         case 'D': {

--- a/src/plugins/tiling/controller.h
+++ b/src/plugins/tiling/controller.h
@@ -44,6 +44,7 @@ void AdjustSpaceGap(char *Op);
 
 bool SendWindowToDesktop(macos_window *Window, char *Op);
 void SendWindowToDesktop(char *Op);
+bool SendWindowToMonitor(macos_window *Window, char *Op);
 void SendWindowToMonitor(char *Op);
 
 void FloatWindow(macos_window *Window);

--- a/src/plugins/tiling/rule.cpp
+++ b/src/plugins/tiling/rule.cpp
@@ -97,6 +97,19 @@ ApplyWindowRuleDesktop(macos_window *Window, window_rule *Rule)
 }
 
 internal inline void
+ApplyWindowRuleMonitor(macos_window *Window, window_rule *Rule)
+{
+    if (SendWindowToMonitor(Window, Rule->Monitor)) {
+        AXLibAddFlags(Window, Rule_Desktop_Changed);
+        if (Rule->FollowDesktop) {
+            FocusMonitor(Rule->Monitor);
+            AXLibSetFocusedWindow(Window->Ref);
+            AXLibSetFocusedApplication(Window->Owner->PSN);
+        }
+    }
+}
+
+internal inline void
 ApplyWindowRuleLevel(macos_window *Window, window_rule *Rule)
 {
     int LevelKey;
@@ -152,6 +165,7 @@ ApplyWindowRule(macos_window *Window, window_rule *Rule)
     }
 
     if (Rule->Desktop)    ApplyWindowRuleDesktop(Window, Rule);
+    if (Rule->Monitor)    ApplyWindowRuleMonitor(Window, Rule);
     if (Rule->State)      ApplyWindowRuleState(Window, Rule);
     if (Rule->Level)      ApplyWindowRuleLevel(Window, Rule);
     if (Rule->Alpha)      ApplyWindowRuleAlpha(Window, Rule);

--- a/src/plugins/tiling/rule.h
+++ b/src/plugins/tiling/rule.h
@@ -18,6 +18,7 @@ struct window_rule
     char *Except;
     char *State;
     char *Desktop;
+    char *Monitor;
     bool FollowDesktop;
     char *Level;
     char *Alpha;


### PR DESCRIPTION
These changes allow writing rules which allow you to send specific windows to specific monitors. This is similar to the desktop rules.

For example, to send Messages windows to monitor 2. We can use the following rule:

```
chunkc tiling::rule --owner Messages --monitor 2 --follow-desktop
```