### PR TITLE
Remove broken docs link to FAQ

### DIFF
--- a/docs/contact.html
+++ b/docs/contact.html
@@ -20,7 +20,6 @@
                     <li><a href="./index.html">Home</a></li>
                     <li><a href="./docs.html">Docs</a></li>
                     <li><a href="./screens.html">Screens</a></li>
-                    <li><a href="#">FAQ</a></li>
                     <li><a href="./contact.html"><span class="active">Contact</span></a></li>
                     <li><a target="_blank" href="https://github.com/koekeishiya/chunkwm">Github</a></li>
                 </ul>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -20,7 +20,6 @@
                     <li><a href="./index.html">Home</a></li>
                     <li><a href="./docs.html"><span class="active">Docs</span></a></li>
                     <li><a href="./screens.html">Screens</a></li>
-                    <li><a href="#">FAQ</a></li>
                     <li><a href="./contact.html">Contact</a></li>
                     <li><a target="_blank" href="https://github.com/koekeishiya/chunkwm">Github</a></li>
                 </ul>

--- a/docs/docs/sa.html
+++ b/docs/docs/sa.html
@@ -20,7 +20,6 @@
                     <li><a href="../index.html">Home</a></li>
                     <li><a href="../docs.html"><span class="active">Docs</span></a></li>
                     <li><a href="../screens.html">Screens</a></li>
-                    <li><a href="#">FAQ</a></li>
                     <li><a href="../contact.html">Contact</a></li>
                     <li><a target="_blank" href="https://github.com/koekeishiya/chunkwm">Github</a></li>
                 </ul>

--- a/docs/docs/source.html
+++ b/docs/docs/source.html
@@ -20,7 +20,6 @@
                     <li><a href="../index.html">Home</a></li>
                     <li><a href="../docs.html"><span class="active">Docs</span></a></li>
                     <li><a href="../screens.html">Screens</a></li>
-                    <li><a href="#">FAQ</a></li>
                     <li><a href="../contact.html">Contact</a></li>
                     <li><a target="_blank" href="https://github.com/koekeishiya/chunkwm">Github</a></li>
                 </ul>

--- a/docs/docs/userguide.html
+++ b/docs/docs/userguide.html
@@ -20,7 +20,6 @@
                     <li><a href="../index.html">Home</a></li>
                     <li><a href="../docs.html"><span class="active">Docs</span></a></li>
                     <li><a href="../screens.html">Screens</a></li>
-                    <li><a href="#">FAQ</a></li>
                     <li><a href="../contact.html">Contact</a></li>
                     <li><a target="_blank" href="https://github.com/koekeishiya/chunkwm">Github</a></li>
                 </ul>

--- a/docs/index.html
+++ b/docs/index.html
@@ -20,7 +20,6 @@
                     <li><a href="./index.html"><span class="active">Home</span></a></li>
                     <li><a href="./docs.html">Docs</a></li>
                     <li><a href="./screens.html">Screens</a></li>
-                    <li><a href="#">FAQ</a></li>
                     <li><a href="./contact.html">Contact</a></li>
                     <li><a target="_blank" href="https://github.com/koekeishiya/chunkwm">Github</a></li>
                 </ul>

--- a/docs/screens.html
+++ b/docs/screens.html
@@ -20,7 +20,6 @@
                     <li><a href="./index.html">Home</a></li>
                     <li><a href="./docs.html">Docs</a></li>
                     <li><a href="./screens.html"><span class="active">Screens</span></a></li>
-                    <li><a href="#">FAQ</a></li>
                     <li><a href="./contact.html">Contact</a></li>
                     <li><a target="_blank" href="https://github.com/koekeishiya/chunkwm">Github</a></li>
                 </ul>


### PR DESCRIPTION
There doesn't seem to be an FAQ page so I've removed the link that goes nowhere.