### PR TITLE
Configure border position

### DIFF
--- a/examples/chunkwmrc
+++ b/examples/chunkwmrc
@@ -88,6 +88,8 @@ chunkc set mouse_motion_interval         35
 
 chunkc set preselect_border_color        0xffd75f5f
 chunkc set preselect_border_width        5
+chunkc set preselect_border_radius       0
+chunkc set preselect_border_outline      0
 
 #
 # NOTE: these settings require chwm-sa.

--- a/examples/chunkwmrc
+++ b/examples/chunkwmrc
@@ -103,10 +103,15 @@ chunkc set window_use_cgs_move           0
 #
 # NOTE: the following are config variables for the chunkwm-border plugin.
 #
+# NOTE: syntax for `focused_border_outline` setting
+#       0 = false, inline border
+#       1 = true, outline border
+#
 
 chunkc set focused_border_color          0xff0f6288
 chunkc set focused_border_width          5
 chunkc set focused_border_radius         0
+chunkc set focused_border_outline        0
 chunkc set focused_border_skip_floating  0
 chunkc set focused_border_skip_monocle   0
 

--- a/src/common/border/border.h
+++ b/src/common/border/border.h
@@ -6,10 +6,11 @@ struct border_window
     int Width;
     int Radius;
     unsigned Color;
+    bool Outline;
 };
 
-border_window *CreateBorderWindow(int X, int Y, int W, int H, int BorderWidth, int BorderRadius, unsigned int BorderColor);
-void UpdateBorderWindowRect(border_window *Border, int X, int Y, int W, int H);
+border_window *CreateBorderWindow(int X, int Y, int W, int H, int BorderWidth, int BorderRadius, unsigned int BorderColor, bool BorderOutline);
+void UpdateBorderWindowRect(border_window *Border, int X, int Y, int W, int H, bool BorderOutline);
 void UpdateBorderWindowColor(border_window *Border, unsigned Color);
 void UpdateBorderWindowWidth(border_window *Border, int BorderWidth);
 void DestroyBorderWindow(border_window *Border);

--- a/src/plugins/border/plugin.mm
+++ b/src/plugins/border/plugin.mm
@@ -55,7 +55,9 @@ CreateBorder(int X, int Y, int W, int H)
     unsigned Color = CVarUnsignedValue("focused_border_color");
     int Width = CVarIntegerValue("focused_border_width");
     int Radius = CVarIntegerValue("focused_border_radius");
-    Border = CreateBorderWindow(X, Y, W, H, Width, Radius, Color);
+    bool Outline = CVarIntegerValue("focused_border_outline");
+
+    Border = CreateBorderWindow(X, Y, W, H, Width, Radius, Color, Outline);
 }
 
 internal inline void

--- a/src/plugins/tiling/constants.h
+++ b/src/plugins/tiling/constants.h
@@ -56,6 +56,7 @@
 #define CVAR_PRE_BORDER_COLOR       "preselect_border_color"
 #define CVAR_PRE_BORDER_WIDTH       "preselect_border_width"
 #define CVAR_PRE_BORDER_RADIUS      "preselect_border_radius"
+#define CVAR_PRE_BORDER_OUTLINE     "preselect_border_outline"
 
 /*
  * NOTE(koekeishiya): The following cvars requires extended dock

--- a/src/plugins/tiling/mouse.cpp
+++ b/src/plugins/tiling/mouse.cpp
@@ -127,12 +127,13 @@ CreateResizeBorder(node *Node, macos_window *Window)
     unsigned PreselectBorderColor = CVarUnsignedValue(CVAR_PRE_BORDER_COLOR);
     int PreselectBorderWidth = CVarIntegerValue(CVAR_PRE_BORDER_WIDTH);
     int PreselectBorderRadius = CVarIntegerValue(CVAR_PRE_BORDER_RADIUS);
+    int PreselectBorderOutline = CVarIntegerValue(CVAR_PRE_BORDER_OUTLINE);
     region PreselRegion = RoundPreselRegion(Node->Region, Window->Position, Window->Size);
     int InvertY = FuckingMacOSMonitorBoundsChangingBetweenPrimaryAndMainMonitor(PreselRegion.Y, PreselRegion.Height);
     border_window *Border = CreateBorderWindow(PreselRegion.X, InvertY,
                                                PreselRegion.Width, PreselRegion.Height,
                                                PreselectBorderWidth, PreselectBorderRadius,
-                                               PreselectBorderColor);
+                                               PreselectBorderColor, PreselectBorderOutline);
     return (resize_border) { Border, Node, Window };
 }
 

--- a/src/plugins/tiling/plugin.mm
+++ b/src/plugins/tiling/plugin.mm
@@ -1685,6 +1685,7 @@ Init(chunkwm_api ChunkwmAPI)
     CreateCVar(CVAR_PRE_BORDER_COLOR, 0xffffff00);
     CreateCVar(CVAR_PRE_BORDER_WIDTH, 4);
     CreateCVar(CVAR_PRE_BORDER_RADIUS, 4);
+    CreateCVar(CVAR_PRE_BORDER_OUTLINE, 0);
 
     /*
      * NOTE(koekeishiya): The following cvars requires extended dock


### PR DESCRIPTION
A simple addition allowing one to configure the border position as either inline (current implementation) or outline. The rule's syntax would be as follows:

- Inline border: `chunkc set focused_border_outline        0` [false, keep current implementation]
- Outline border: `chunkc set focused_border_outline        1` [true, positions border outside window]

