### PR TITLE
#477 add query to get window list on a specific desktop

### DIFF
--- a/src/plugins/tiling/README.md
+++ b/src/plugins/tiling/README.md
@@ -71,6 +71,7 @@
   * [query monitor related](#query-monitor-related)
       * [query focused monitor](#query-focused-monitor-id)
       * [query monitor count](#query-monitor-count)
+  * [query windows for desktop](#query-windows-for-desktop)
   * [query desktops for monitor](#query-desktops-for-monitor)
   * [query monitor for desktop](#query-monitor-for-desktop)
 
@@ -535,6 +536,11 @@ See the following sections for how to retrieve information about an open window:
 
     chunkc tiling::query --monitor count
     short flag: m
+
+##### query windows for desktop
+
+    chunkc tiling::query --windows-for-desktop <desktop id>
+    short flag: W
 
 ##### query desktops for monitor
 

--- a/src/plugins/tiling/config.cpp
+++ b/src/plugins/tiling/config.cpp
@@ -513,6 +513,7 @@ query_func QueryCommandDispatch(char Flag)
     case 'w': return QueryWindow;             break;
     case 'd': return QueryDesktop;            break;
     case 'm': return QueryMonitor;            break;
+    case 'W': return QueryWindowsForDesktop;  break;
     case 'D': return QueryDesktopsForMonitor; break;
     case 'M': return QueryMonitorForDesktop;  break;
 
@@ -534,6 +535,7 @@ ParseQueryCommand(const char *Message, command *Chain)
         { "window", required_argument, NULL, 'w' },
         { "desktop", required_argument, NULL, 'd' },
         { "monitor", required_argument, NULL, 'm' },
+        { "windows-for-desktop", required_argument, NULL, 'W' },
         { "desktops-for-monitor", required_argument, NULL, 'D' },
         { "monitor-for-desktop", required_argument, NULL, 'M' },
         { NULL, 0, NULL, 0 }
@@ -590,6 +592,7 @@ ParseQueryCommand(const char *Message, command *Chain)
                 goto End;
             }
         } break;
+        case 'W':
         case 'D':
         case 'M': {
             int Integer;

--- a/src/plugins/tiling/controller.h
+++ b/src/plugins/tiling/controller.h
@@ -60,6 +60,7 @@ void DestroyDesktop(char *Unused);
 void QueryWindow(char *Op, int SockFD);
 void QueryDesktop(char *Op, int SockFD);
 void QueryMonitor(char *Op, int SockFD);
+void QueryWindowsForDesktop(char *Op, int SockFD);
 void QueryDesktopsForMonitor(char *Op, int SockFD);
 void QueryMonitorForDesktop(char *Op, int SockFD);
 


### PR DESCRIPTION
Add a --windows-for-desktop option for getting the list of windows on a specific space, similar to the --desktops-for-monitor option.