### PR TITLE
Fixing empty desktop not working with prev/next monitor

### DIFF
--- a/src/plugins/tiling/controller.cpp
+++ b/src/plugins/tiling/controller.cpp
@@ -1882,6 +1882,8 @@ FocusMonitor(unsigned MonitorId)
     Space = AXLibActiveSpace(MonitorRef);
     ASSERT(Space);
 
+    Result = true;
+
     IncludeInvalidWindows = (Space->Type != kCGSSpaceUser);
 
     WindowIds = GetAllVisibleWindowsForSpace(Space, IncludeInvalidWindows, true);
@@ -1893,8 +1895,6 @@ FocusMonitor(unsigned MonitorId)
 
     Window = GetWindowByID(WindowIds[0]);
     FocusWindow(Window);
-
-    Result = true;
 
 space_free:
     AXLibDestroySpace(Space);


### PR DESCRIPTION
This fixes #464 when using `chunkc tiling::monitor -f prev/next` when switching to an empty desktop.