### PR TITLE
Use space float mode for focus follow mouse deactivation and monitor switching

### DIFF
--- a/src/plugins/ffm/README.md
+++ b/src/plugins/ffm/README.md
@@ -3,6 +3,7 @@
 * [config settings](#config-settings)
   * [bypass ffm temporarily](#bypass-ffm-temporarily)
   * [standby on float](#standby-on-float)
+  * [always switch on display change](#always-switch-on-display-change)
 
 #### config settings
 
@@ -17,3 +18,9 @@
     chunkc set ffm_standby_on_float <option>
     <option>: 1 | 0
     desc: temporarily disable ffm when a floating window gets focus
+
+##### always switch on display change
+
+    chunkc set ffm_always_switch_display <option>
+    <option>: 1 | 0
+    desc: moving cursor to another display will always raise the display

--- a/src/plugins/ffm/makefile
+++ b/src/plugins/ffm/makefile
@@ -1,8 +1,8 @@
 BUILD_FLAGS		= -O0 -g -DCHUNKWM_DEBUG -std=c++11 -Wall
 BUILD_PATH		= ./../../../plugins
-SRC				= ./plugin.cpp
+SRC				= ./plugin.mm
 BINS			= $(BUILD_PATH)/ffm.so
-LINK			= -shared -fPIC -framework Carbon -framework ApplicationServices
+LINK			= -shared -fPIC -framework Carbon -framework Cocoa -framework ApplicationServices
 
 all: $(BINS)
 


### PR DESCRIPTION
This implements also disabling focus follow mouse in float desktop mode, if ffm_standby_on_float is enabled.

When implementing this feature I noticed the behavior on multi monitor switch to be quite unintuitive (as moving the mouse into a tiling space would not toggle the switch again), why I implemented a separate ffm_always_switch_display toggle, which would enable ffm always when moving across monitor borders.