### PR TITLE
Use 'em' for font sizes so users can zoom in on the website

### DIFF
--- a/docs/styles/style.css
+++ b/docs/styles/style.css
@@ -5,6 +5,7 @@ body {
     background-color: #202020;
     height: 100vh;
     overflow: hidden;
+    font-size: 14px;
 }
 
 pre {
@@ -67,13 +68,13 @@ a:hover {
 }
 
 #navbar-text h4 {
-    font-size: 2.19vmin;
+    font-size: 1.5em;
     margin-bottom: 0;
     color: #dfdfdf;
 }
 
 #navbar-text p {
-    font-size: 1.44vmin;
+    font-size: 1em;
     margin-top: 0;
     color: #8fee96;
 }
@@ -81,7 +82,7 @@ a:hover {
 #navbar-menu {
     float: right;
     padding-top: 4.4vmin;
-    font-size: 1.75vmin;
+    font-size: 1.2em;
 }
 
 #navbar-menu li {
@@ -120,7 +121,6 @@ a:hover {
 }
 
 #contents {
-    font-size: 1.5vmin;
     color: #d5c4a1;
     overflow-y: scroll;
     overflow-x: hidden;
@@ -146,7 +146,7 @@ a:hover {
 }
 
 #footer {
-    font-size: 1.08vmin;
+    font-size: .75em;
     color: #8fee96;
     overflow: hidden;
     position: absolute;


### PR DESCRIPTION
This was one of the requests mentioned in #576. It's not pixel-perfect but it's pretty close. Happy to help with the others if you're open to that. 

Thanks for the great project, I use chunkwm and skhd every day.

Before:
<img width="970" alt="screen shot 2019-03-05 at 10 04 59 pm" src="https://user-images.githubusercontent.com/284902/53853291-d69e8980-3f92-11e9-8e8c-60b236e0f8b2.png">

After:
<img width="957" alt="screen shot 2019-03-05 at 10 05 09 pm" src="https://user-images.githubusercontent.com/284902/53853294-d900e380-3f92-11e9-9d67-22e43d23bdc1.png">