### PR TITLE
Be clear about the usage of sudo when loading the SA

### DIFF
--- a/docs/docs/sa.html
+++ b/docs/docs/sa.html
@@ -78,7 +78,7 @@
             </p>
 
             <p>
-                When the scripting-addition has been installed, you can load it by running: <em>chunkwm --load-sa</em></br>
+                When the scripting-addition has been installed, you can load it by running: <em>sudo chunkwm --load-sa</em></br>
                 <em>chunkwm</em> will automatically load the scripting addition at startup, or when the Dock is (re)launched.
             </p>
 


### PR DESCRIPTION
Following the discussion [here](https://github.com/koekeishiya/chunkwm/issues/626) this PR updates the docs to include `sudo` in the `chunkwm --load-sa` command.
