### PR TITLE
Added rule filters for "max height" and "max width".

### DIFF
--- a/src/plugins/tiling/config.cpp
+++ b/src/plugins/tiling/config.cpp
@@ -634,7 +634,7 @@ ParseRuleCommand(const char *Message, window_rule *Rule)
 
     int Option;
     bool Success = true;
-    const char *Short = "o:n:r:R:e:s:d:Dl:a:g:";
+    const char *Short = "o:n:r:R:e:h:w:s:d:Dl:a:g:";
 
     struct option Long[] = {
         { "owner", required_argument, NULL, 'o' },
@@ -642,6 +642,8 @@ ParseRuleCommand(const char *Message, window_rule *Rule)
         { "role", required_argument, NULL, 'r' },
         { "subrole", required_argument, NULL, 'R' },
         { "except", required_argument, NULL, 'e' },
+        { "max-height", required_argument, NULL, 'h' },
+        { "max-width", required_argument, NULL, 'w' },
         { "state", required_argument, NULL, 's' },
         { "desktop", required_argument, NULL, 'd' },
         { "monitor", required_argument, NULL, 'm' },
@@ -675,6 +677,14 @@ ParseRuleCommand(const char *Message, window_rule *Rule)
         } break;
         case 'e': {
             Rule->Except = strdup(optarg);
+            HasFilter = true;
+        } break;
+        case 'h': {
+            Rule->MaxHeight = strdup(optarg);
+            HasFilter = true;
+        } break;
+        case 'w': {
+            Rule->MaxWidth = strdup(optarg);
             HasFilter = true;
         } break;
         case 's': {

--- a/src/plugins/tiling/controller.cpp
+++ b/src/plugins/tiling/controller.cpp
@@ -2545,9 +2545,11 @@ QueryWindowsForActiveSpace(int SockFD)
         ASSERT(Window);
 
         if (IsWindowValid(Window)) {
-            BytesWritten = snprintf(Cursor, BufferSize, "%d, %s, %s\n", Window->Id, Window->Owner->Name, Window->Name);
+            BytesWritten = snprintf(Cursor, BufferSize, "%d, %s, %s, %1.0lf x %1.0lf\n",
+                Window->Id, Window->Owner->Name, Window->Name, Window->Size.height, Window->Size.width);
         } else {
-            BytesWritten = snprintf(Cursor, BufferSize, "%d, %s, %s (invalid)\n", Window->Id, Window->Owner->Name, Window->Name);
+            BytesWritten = snprintf(Cursor, BufferSize, "%d, %s, %s, %1.0lf x %1.0lf (invalid)\n",
+                Window->Id, Window->Owner->Name, Window->Name, Window->Size.height, Window->Size.width);
         }
 
         ASSERT(BytesWritten >= 0);

--- a/src/plugins/tiling/rule.cpp
+++ b/src/plugins/tiling/rule.cpp
@@ -165,6 +165,18 @@ ApplyWindowRule(macos_window *Window, window_rule *Rule)
         if (!Match) return;
     }
 
+    if (Rule->MaxHeight) {
+        double MaxH = atof(Rule->MaxHeight);
+        Match &= (MaxH > 0) && (MaxH > (double)(Window->Size.height));
+        if (!Match) return;
+    }
+
+    if (Rule->MaxWidth) {
+        double MaxW = atof(Rule->MaxWidth);
+        Match &= (MaxW > 0) && (MaxW > (double)(Window->Size.width));
+        if (!Match) return;
+    }
+
     if (Rule->Desktop)    ApplyWindowRuleDesktop(Window, Rule);
     if (Rule->Monitor)    ApplyWindowRuleMonitor(Window, Rule);
     if (Rule->State)      ApplyWindowRuleState(Window, Rule);

--- a/src/plugins/tiling/rule.h
+++ b/src/plugins/tiling/rule.h
@@ -17,6 +17,8 @@ struct window_rule
     CFStringRef Role;
     CFStringRef Subrole;
     char *Except;
+    char* MaxHeight;
+    char* MaxWidth;
     char *State;
     char *Desktop;
     char *Monitor;


### PR DESCRIPTION
Added the ability to run rules on windows that are under a certain height and width constraint. For easier debugging, this merge also prints a windows's height and width when running the query `chuckc tiling::query --desktop windows`.

I don't expect this to be merged (as I hear there are plans for a full-fledged "query" language to help filter rules). Nonetheless, if someone else wants to use these changes temporarily until this feature is implemented, it's pretty easy to swap out the `tiling.so` file into your brew installation.